### PR TITLE
docs: add domain organization pattern and update coding patterns

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -106,6 +106,14 @@ None in MVP. Infrastructure decisions deferred to post-MVP.
 
 ## Decision Log
 
+### 2026-03-10 — Subdomain folders for multi-entity domains
+
+**Context:** The Crop domain has 3 entities (CropType, Variety, Harvest) with 200+ files across frontend and backend. Maintaining all files in a single flat folder became unwieldy.
+**Decision:** Multi-entity domains use subdomain folders within the domain folder. Each subdomain mirrors the standard domain structure (enterprise/application for backend, actions/api/components/schemas/store for frontend). Infrastructure layers (controllers, mappers, repositories, events modules) stay flat.
+**Options considered:** (A) Subdomain folders within the domain (chosen) / (B) Separate top-level domains per entity
+**Rationale:** Option A preserves the bounded context — CropType, Variety, and Harvest share business rules and reference each other. Option B would lose this semantic grouping and make cross-entity relationships implicit. Infrastructure stays flat because NestJS modules are the unit of composition and splitting them per entity adds unnecessary fragmentation.
+**Consequences:** Import paths change from `@/domain/crop/enterprise/entities/crop-type` to `@/domain/crop/crop-types/enterprise/entities/crop-type`. All coding pattern docs updated with subdomain notes. See `coding-patterns/frontend/domain-organization.md` and `coding-patterns/backend/domain-organization.md`.
+
 ### 2026-03-09 — Single-tenant MVP with multi-tenant awareness
 
 **Context:** The app will be a SaaS, but MVP targets a single farm for testing.

--- a/coding-patterns/backend/domain-organization.md
+++ b/coding-patterns/backend/domain-organization.md
@@ -1,0 +1,288 @@
+# Domain Organization Pattern
+
+Domains are top-level folders under `src/domain/`. Each domain maps to a bounded context from `docs/rules/<domain>.md`. This document defines when and how to organize domains — including multi-entity domains that require subdomain folders.
+
+---
+
+## Decision: flat vs subdomain structure
+
+A domain starts flat. When it grows to contain **two or more entities with full CRUD**, split into subdomain folders.
+
+| Scenario | Structure | Example |
+|----------|-----------|---------|
+| Single entity or simple domain | Flat | `domain/audit-log/` |
+| Multiple entities in the same bounded context | Subdomain folders | `domain/crop/crop-types/`, `domain/crop/varieties/` |
+
+---
+
+## Flat domain structure
+
+```
+src/domain/<domain>/
+  enterprise/
+    entities/
+      <entity>.ts
+    events/
+      <entity>-created-event.ts
+      <entity>-updated-event.ts
+      <entity>-deleted-event.ts
+  application/
+    use-cases/
+      create-<entity>.ts
+      edit-<entity>.ts
+      delete-<entity>.ts
+      find-<entity>-by-id.ts
+      list-<entity>s.ts
+      __tests__/
+        create-<entity>.spec.ts
+        ...
+      errors/
+        <entity>-not-found-error.ts
+        ...
+    repositories/
+      <entity>s-repository.ts
+```
+
+---
+
+## Subdomain structure
+
+When the domain has multiple entities, each entity gets its own subdomain folder mirroring the flat structure:
+
+```
+src/domain/<domain>/
+  <entity-a>/
+    enterprise/
+      entities/
+        <entity-a>.ts
+      events/
+        <entity-a>-created-event.ts
+        <entity-a>-updated-event.ts
+        <entity-a>-deleted-event.ts
+    application/
+      use-cases/
+        create-<entity-a>.ts
+        edit-<entity-a>.ts
+        delete-<entity-a>.ts
+        find-<entity-a>-by-id.ts
+        list-<entity-a>s.ts
+        __tests__/
+          create-<entity-a>.spec.ts
+          ...
+        errors/
+          <entity-a>-not-found-error.ts
+          ...
+      repositories/
+        <entity-a>s-repository.ts
+  <entity-b>/
+    enterprise/
+      entities/
+      events/
+    application/
+      use-cases/
+        __tests__/
+        errors/
+      repositories/
+  <entity-c>/
+    enterprise/
+    application/
+```
+
+**Example:** `domain/crop/` with subdomains `crop-types/`, `varieties/`, `harvests/`.
+
+---
+
+## Infrastructure layer
+
+The infrastructure layer mirrors the domain structure:
+
+### Flat domain
+
+```
+src/infra/
+  http/controllers/<domain>/
+    create-<entity>.controller.ts
+    <domain>-http.module.ts
+  database/prisma/
+    mappers/<domain>/
+      prisma-<entity>.mapper.ts
+    repositories/<domain>/
+      prisma-<entity>s.repository.ts
+      <domain>-database.module.ts
+  events/<domain>/
+    <domain>-events.module.ts
+```
+
+### Subdomain — infrastructure mirrors domain subdomains
+
+The infrastructure layer also uses subdomain folders for controllers, mappers, and repositories. NestJS modules and error filters stay at the `<domain>/` level since they wire all entities together.
+
+```
+src/infra/
+  http/
+    controllers/<domain>/
+      <subdomain-a>/
+        create-<entity-a>.controller.ts
+        edit-<entity-a>.controller.ts
+        ...
+      <subdomain-b>/
+        create-<entity-b>.controller.ts
+        ...
+      <domain>-http.module.ts            ← single module at domain level
+    presenters/<domain>/
+      <entity-a>.presenter.ts            ← flat under domain (one file per entity)
+      <entity-b>.presenter.ts
+      <entity-c>.presenter.ts
+    filters/
+      <domain>-error.filter.ts           ← single filter at domain level
+    dtos/
+      error/<domain>/
+        <subdomain-a>/
+          <entity-a>-not-found.dto.ts
+        <subdomain-b>/
+          ...
+      requests/<domain>/
+        <subdomain-a>/
+          create-<entity-a>-request.dto.ts
+        <subdomain-b>/
+          ...
+      response/<domain>/
+        <subdomain-a>/
+          <entity-a>-response.dto.ts
+        <subdomain-b>/
+          ...
+  database/prisma/
+    mappers/<domain>/
+      <subdomain-a>/
+        prisma-<entity-a>.mapper.ts
+      <subdomain-b>/
+        prisma-<entity-b>.mapper.ts
+    repositories/<domain>/
+      <subdomain-a>/
+        prisma-<entity-a>s.repository.ts
+      <subdomain-b>/
+        prisma-<entity-b>s.repository.ts
+      <domain>-database.module.ts        ← single module at domain level
+  events/<domain>/
+    <domain>-events.module.ts            ← single module at domain level
+```
+
+**What stays flat (at domain level):**
+- NestJS modules (`*-http.module.ts`, `*-database.module.ts`, `*-events.module.ts`) — they wire all entities together
+- Error filters — they handle errors from all entities in the domain
+- Presenters — one file per entity, flat under `presenters/<domain>/`
+
+**What splits into subdomains:**
+- Controllers, mappers, Prisma repositories, DTOs — these are per-entity and benefit from the same organization as the domain layer
+
+---
+
+## Test infrastructure
+
+Test helpers mirror the domain structure:
+
+### Flat domain
+
+```
+test/
+  factories/
+    make-<entity>.ts
+  repositories/<domain>/
+    in-memory-<entity>s-repository.ts
+```
+
+### Subdomain — test repos mirror domain, factories stay flat
+
+In-memory repositories mirror the domain subdomain structure. Factories stay flat since they are simple one-file-per-entity helpers.
+
+```
+test/
+  factories/
+    make-<entity-a>.ts                        ← flat (one file per entity)
+    make-<entity-b>.ts
+    make-<entity-c>.ts
+  repositories/<domain>/
+    <subdomain-a>/
+      in-memory-<entity-a>s-repository.ts
+    <subdomain-b>/
+      in-memory-<entity-b>s-repository.ts
+    <subdomain-c>/
+      in-memory-<entity-c>s-repository.ts
+```
+
+---
+
+## Import paths
+
+### Flat domain
+
+```ts
+import { AuditLog } from '@/domain/audit-log/enterprise/entities/audit-log'
+import { CreateAuditLogUseCase } from '@/domain/audit-log/application/use-cases/create-audit-log'
+```
+
+### Subdomain
+
+```ts
+import { CropType } from '@/domain/crop/crop-types/enterprise/entities/crop-type'
+import { CreateCropTypeUseCase } from '@/domain/crop/crop-types/application/use-cases/create-crop-type'
+
+import { Variety } from '@/domain/crop/varieties/enterprise/entities/variety'
+import { CreateVarietyUseCase } from '@/domain/crop/varieties/application/use-cases/create-variety'
+```
+
+---
+
+## Cross-subdomain references
+
+Entities within the same domain may reference each other. This is expected — they share a bounded context.
+
+```ts
+// domain/crop/varieties/application/use-cases/create-variety.ts
+import { CropTypesRepository } from '@/domain/crop/crop-types/application/repositories/crop-types-repository'
+```
+
+```ts
+// domain/crop/harvests/application/use-cases/create-harvest.ts
+import { CropTypesRepository } from '@/domain/crop/crop-types/application/repositories/crop-types-repository'
+import { VarietiesRepository } from '@/domain/crop/varieties/application/repositories/varieties-repository'
+```
+
+**Cross-domain references** (between different bounded contexts) use domain events, never direct imports.
+
+---
+
+## Subdomain naming
+
+Use the **plural entity name** in kebab-case:
+
+| Entity | Subdomain folder |
+|--------|-----------------|
+| CropType | `crop-types/` |
+| Variety | `varieties/` |
+| Harvest | `harvests/` |
+
+---
+
+## When to create a new subdomain
+
+Add a new subdomain folder when the domain gains a new entity that has:
+
+1. Its own aggregate root (entity with identity)
+2. Its own repository interface
+3. Its own use cases (create, edit, delete, list, find)
+4. Its own domain events
+
+Value objects used by an entity stay in that entity's `enterprise/entities/` folder.
+
+---
+
+## Migration: flat → subdomain
+
+When a flat domain grows to need subdomains:
+
+1. Create subdomain folders matching entity names
+2. Move entity, events, use cases, errors, and repository interface into respective subdomains
+3. Update all import paths across `src/` and `test/`
+4. Infrastructure modules (`*-http.module.ts`, `*-database.module.ts`, `*-events.module.ts`) keep their flat structure — only update import paths to point at subdomain locations
+5. Run `pnpm test` and `pnpm test:e2e` to verify no broken imports

--- a/coding-patterns/backend/entity.md
+++ b/coding-patterns/backend/entity.md
@@ -10,6 +10,8 @@ Entities are the core of the domain layer. They encapsulate identity, state, and
 src/domain/<domain>/enterprise/entities/<Entity>.ts
 ```
 
+> **Multi-entity domains:** When the domain uses subdomain folders (see `domain-organization.md`), entities move under the subdomain: `src/domain/<domain>/<subdomain>/enterprise/entities/<Entity>.ts`.
+
 ---
 
 ## Base classes (src/core/)

--- a/coding-patterns/backend/events.md
+++ b/coding-patterns/backend/events.md
@@ -12,6 +12,8 @@ src/domain/<reacting-domain>/application/subscribers/<entity>/on-<entity>-<actio
 src/infra/events/<domain>/<domain>-events.module.ts                  ← NestJS wiring
 ```
 
+> **Multi-entity domains:** When the domain uses subdomain folders (see `domain-organization.md`), events move under the subdomain: `src/domain/<domain>/<subdomain>/enterprise/events/`. The infra events module stays flat.
+
 ---
 
 ## 1. Domain Event

--- a/coding-patterns/backend/mapper.md
+++ b/coding-patterns/backend/mapper.md
@@ -10,6 +10,8 @@ Mappers translate between Prisma records and domain entities. They are static ut
 src/infra/database/prisma/mappers/<domain>/prisma-<entity>.mapper.ts
 ```
 
+> **Multi-entity domains:** When the domain uses subdomain folders (see `domain-organization.md`), mappers also use subdomain folders: `src/infra/database/prisma/mappers/<domain>/<subdomain>/`.
+
 ---
 
 ## Structure

--- a/coding-patterns/backend/repository.md
+++ b/coding-patterns/backend/repository.md
@@ -14,6 +14,8 @@ src/infra/database/prisma/repositories/<domain>/prisma-<entity>.repository.ts  â
 test/repositories/<domain>/in-memory-<entity>-repository.ts           â† in-memory implementation for tests
 ```
 
+> **Multi-entity domains:** When the domain uses subdomain folders (see `domain-organization.md`), the repository interface moves under the subdomain: `src/domain/<domain>/<subdomain>/application/repositories/`. Infrastructure implementations and test repositories also use subdomain folders: `src/infra/database/prisma/repositories/<domain>/<subdomain>/` and `test/repositories/<domain>/<subdomain>/`.
+
 ---
 
 ## 1. Repository interface (domain layer)

--- a/coding-patterns/backend/use-case.md
+++ b/coding-patterns/backend/use-case.md
@@ -11,6 +11,8 @@ src/domain/<domain>/application/use-cases/<action>-<entity>.ts
 src/domain/<domain>/application/use-cases/errors/<entity>-<problem>-error.ts
 ```
 
+> **Multi-entity domains:** When the domain uses subdomain folders (see `domain-organization.md`), use cases move under the subdomain: `src/domain/<domain>/<subdomain>/application/use-cases/`.
+
 One file per use case. One use case per file.
 
 ---

--- a/coding-patterns/frontend/action.md
+++ b/coding-patterns/frontend/action.md
@@ -15,6 +15,8 @@ src/domains/<domain>/actions/index.ts                        ← barrel export
 src/shared/constants/messages.ts                             ← DEFAULT_ERROR_MESSAGE
 ```
 
+> **Multi-entity domains:** When the domain uses subdomain folders (see `domain-organization.md`), actions move under the subdomain: `src/domains/<domain>/<subdomain>/actions/`.
+
 One action per operation. One file per action.
 
 ---

--- a/coding-patterns/frontend/api.md
+++ b/coding-patterns/frontend/api.md
@@ -16,6 +16,8 @@ src/domains/<domain>/api/toggle-<entity>-status.ts    ← PATCH toggle
 src/domains/<domain>/api/index.ts                     ← barrel export
 ```
 
+> **Multi-entity domains:** When the domain uses subdomain folders (see `domain-organization.md`), API functions move under the subdomain: `src/domains/<domain>/<subdomain>/api/`.
+
 One function per endpoint. One file per function.
 
 ---

--- a/coding-patterns/frontend/component.md
+++ b/coding-patterns/frontend/component.md
@@ -13,6 +13,8 @@ src/domains/<domain>/components/
   index.ts                            ← barrel export
 ```
 
+> **Multi-entity domains:** When the domain uses subdomain folders (see `domain-organization.md`), components move under the subdomain: `src/domains/<domain>/<subdomain>/components/`.
+
 ### Grouping rules
 
 Components are grouped into subdirectories when **two or more components share the same category**. Groups are not fixed — they emerge from the domain's needs. Name the directory after what the components have in common.

--- a/coding-patterns/frontend/design-system.md
+++ b/coding-patterns/frontend/design-system.md
@@ -407,6 +407,7 @@ shadcn/ui components live in `src/shared/components/ui/`. They are the building 
 - **Layout is project-specific** — document in `layout.md` when defined
 - **No formal styleguide by default** — coding patterns are the source of truth. Add Storybook or `/styleguide` page if the project needs it.
 - **shadcn/ui primitives are immutable** — wrap, don't modify
+- **Never use `!important`** — no `!h-4`, `!p-0`, `!text-sm` or any Tailwind `!` prefix. If specificity is needed, restructure the HTML or use more specific selectors.
 
 ---
 
@@ -458,4 +459,9 @@ shadcn/ui components live in `src/shared/components/ui/`. They are the building 
 // WRONG: defining colors in tailwind.config.ts
 module.exports = { theme: { colors: { primary: '#000' } } }
 // CORRECT: define in globals.css via :root + @theme inline
+
+// WRONG: using !important via Tailwind prefix
+<Separator className="!h-4" />
+// CORRECT: restructure to avoid specificity conflicts
+<Separator className="h-4" />
 ```

--- a/coding-patterns/frontend/domain-organization.md
+++ b/coding-patterns/frontend/domain-organization.md
@@ -1,0 +1,336 @@
+# Domain Organization Pattern
+
+Domains are top-level folders under `src/domains/`. Each domain maps to a bounded context from `docs/rules/<domain>.md`. This document defines when and how to organize domains — including multi-entity domains that require subdomain folders.
+
+---
+
+## Decision: flat vs subdomain structure
+
+A domain starts flat. When it grows to contain **two or more entities with full CRUD**, split into subdomain folders.
+
+| Scenario | Structure | Example |
+|----------|-----------|---------|
+| Single entity or simple domain | Flat | `domains/audit-log/` |
+| Multiple entities in the same bounded context | Subdomain folders | `domains/crop/crop-types/`, `domains/crop/varieties/` |
+
+**Rule of thumb:** if the domain has more than ~30 files across actions/api/schemas/components, it needs subdomain folders. Don't wait until it's unmanageable — split early.
+
+---
+
+## Flat domain structure
+
+Used when the domain has a single entity or a small set of closely related operations.
+
+```
+src/domains/<domain>/
+  actions/
+    create-<entity>.ts
+    edit-<entity>.ts
+    delete-<entity>.ts
+    index.ts
+  api/
+    list-<entity>s.ts
+    find-<entity>-by-id.ts
+    create-<entity>.ts
+    edit-<entity>.ts
+    delete-<entity>.ts
+    index.ts
+  components/
+    table/
+    forms/
+    dialogs/
+    sheets/
+    ui/
+    index.ts
+  schemas/
+    <entity>.schema.ts
+    create-<entity>.schema.ts
+    edit-<entity>.schema.ts
+    list-<entity>s.schema.ts
+    index.ts
+  store/
+    <entity>-dialogs.store.ts
+    index.ts
+  index.ts                          ← optional, re-exports from subdirectories
+```
+
+**Example:** `domains/audit-log/` — single entity, append-only, no mutations from UI.
+
+---
+
+## Subdomain structure
+
+Used when the domain contains multiple entities that belong to the same bounded context (share business rules, reference each other).
+
+```
+src/domains/<domain>/
+  <entity-a>/
+    actions/
+      create-<entity-a>.ts
+      edit-<entity-a>.ts
+      delete-<entity-a>.ts
+      index.ts
+    api/
+      list-<entity-a>s.ts
+      find-<entity-a>-by-id.ts
+      create-<entity-a>.ts
+      edit-<entity-a>.ts
+      delete-<entity-a>.ts
+      index.ts
+    components/
+      table/
+      forms/
+      dialogs/
+      sheets/
+      ui/
+      index.ts
+    schemas/
+      <entity-a>.schema.ts
+      create-<entity-a>.schema.ts
+      edit-<entity-a>.schema.ts
+      list-<entity-a>s.schema.ts
+      index.ts
+    store/
+      <entity-a>-dialogs.store.ts
+      index.ts
+  <entity-b>/
+    actions/
+    api/
+    components/
+    schemas/
+    store/
+  <entity-c>/
+    actions/
+    api/
+    components/
+    schemas/
+    store/
+```
+
+Each subdomain folder mirrors the flat domain structure exactly — same directories, same naming conventions, same barrel exports.
+
+**Example:** `domains/crop/` with subdomains `crop-types/`, `varieties/`, `harvests/`.
+
+---
+
+## Import paths
+
+### Flat domain
+
+```ts
+import { listAuditLogs } from '@/domains/audit-log/api'
+import { AuditLogTable } from '@/domains/audit-log/components'
+import type { AuditLog } from '@/domains/audit-log/schemas'
+```
+
+### Subdomain
+
+```ts
+import { listCropTypes } from '@/domains/crop/crop-types/api'
+import { CropTypeTable } from '@/domains/crop/crop-types/components'
+import type { CropType } from '@/domains/crop/crop-types/schemas'
+
+import { listVarieties } from '@/domains/crop/varieties/api'
+import { VarietyTable } from '@/domains/crop/varieties/components'
+
+import { createHarvestAction } from '@/domains/crop/harvests/actions'
+```
+
+No root-level `index.ts` re-exporting everything — import directly from the subdomain to keep dependencies explicit and tree-shaking effective.
+
+---
+
+## Cross-subdomain imports
+
+Entities within the same domain may reference each other. This is expected and allowed — they share a bounded context.
+
+```ts
+// domains/crop/varieties/components/forms/create-variety-form.tsx
+import { listCropTypes } from '@/domains/crop/crop-types/api'
+```
+
+```ts
+// domains/crop/harvests/components/forms/create-harvest-form.tsx
+import { listCropTypes } from '@/domains/crop/crop-types/api'
+import { listVarieties } from '@/domains/crop/varieties/api'
+```
+
+**Rule:** Cross-domain imports (between different bounded contexts) go through API functions or events, never direct entity imports.
+
+---
+
+## Subdomain naming
+
+Use the **plural entity name** as the subdomain folder name, matching the URL segment:
+
+| Entity | Subdomain folder | URL |
+|--------|-----------------|-----|
+| CropType | `crop-types/` | `/crop-types` |
+| Variety | `varieties/` | `/varieties` |
+| Harvest | `harvests/` | `/harvests` |
+
+---
+
+## Pages (App Router)
+
+Pages remain at the top level under `app/(private)/`, not nested under the domain folder. The route structure mirrors the subdomain naming:
+
+```
+src/app/(private)/
+  crop-types/
+    page.tsx                    ← list
+    loading.tsx
+    [id]/
+      page.tsx                  ← detail
+      loading.tsx
+      not-found.tsx
+      audit/
+        page.tsx                ← audit sub-page
+        loading.tsx
+  varieties/
+    page.tsx
+    loading.tsx
+    [id]/
+      page.tsx
+      loading.tsx
+      not-found.tsx
+      audit/
+        page.tsx
+        loading.tsx
+  harvests/
+    page.tsx
+    loading.tsx
+    [id]/
+      page.tsx
+      loading.tsx
+      not-found.tsx
+      audit/
+        page.tsx
+        loading.tsx
+```
+
+---
+
+## Detail page structure
+
+Every detail page follows the `DetailLayout` pattern with three slots:
+
+```tsx
+<DetailLayout
+  header={<DetailHeader ... />}
+  main={
+    <>
+      {/* Relationship sections — limited to 5 items */}
+      <DetailSection title="Related Entities">
+        {data.length > 0 ? (
+          <EntityTable data={data} />
+        ) : (
+          <EmptyState icon={Icon} message="No items" />
+        )}
+      </DetailSection>
+
+      {/* Audit section — always last in main */}
+      <DetailSection title="Auditoria">
+        {auditLogs.data.length > 0 ? (
+          <LimitedAuditLogs
+            logs={auditLogs.data}
+            moreHref={`/<entities>/${id}/audit`}
+          />
+        ) : (
+          <EmptyState icon={Icon} message="Nenhum registro de auditoria" />
+        )}
+      </DetailSection>
+    </>
+  }
+  sidebar={
+    <DetailSection title="Detalhes">
+      <div className="flex flex-col gap-4">
+        <DetailField label="Field" icon={Icon}>value</DetailField>
+        {/* Linked references use Link component */}
+        <DetailField label="Related Entity" icon={Icon}>
+          <Link href={`/<related>/${entity.relatedId}`}
+            className="text-primary underline-offset-4 hover:underline">
+            {relatedName}
+          </Link>
+        </DetailField>
+      </div>
+    </DetailSection>
+  }
+/>
+```
+
+### Rules
+
+1. **Relationship tables** in main are limited to 5 items via the API call (`limit: 5` or `perPage: 5`)
+2. **Audit preview** uses `LimitedAuditLogs` (list format), never `AuditLogTable` — the table is only for the dedicated `/audit` sub-page
+3. **`LimitedAuditLogs`** includes its own "Examinar mais itens" link — do not add `linkHref`/`linkLabel` to the wrapping `DetailSection`
+4. **Relationship sections** use `DetailSection` with `linkHref` and `linkLabel="Examinar mais itens"` pointing to the filtered list page
+5. **Sidebar** shows entity details with `DetailField` components — reference entities are links
+6. **Data fetching** uses `Promise.all` for parallel independent fetches
+7. **Audit API call** always uses `listAuditLogs({ entity: '<ENTITY>', entityId: id, limit: 5 })`
+
+---
+
+## Audit sub-page structure
+
+Each entity has an audit sub-page at `/<entities>/[id]/audit`:
+
+```tsx
+// src/app/(private)/<entities>/[id]/audit/page.tsx
+export default async function EntityAuditPage(props: NextPageProps<{ id: string }>) {
+  const params = await props.params
+  const searchParams = await props.searchParams
+  const id = params.id
+  const cursor = getSearchParam(searchParams['cursor'])
+
+  const auditLogs = await listAuditLogs({
+    entity: '<ENTITY>',
+    entityId: id,
+    limit: 20,
+    cursor: cursor ?? undefined,
+  })
+
+  return (
+    <DetailLayout
+      header={<DetailHeader backHref={`/<entities>/${id}`} backLabel="Entity Name" title="Auditoria" icon={Icon} />}
+      main={
+        <DetailSection title="Registros de Auditoria">
+          <AuditLogTable data={auditLogs.data} />
+          {auditLogs.meta.nextCursor && (
+            <Link href={`/<entities>/${id}/audit?cursor=${auditLogs.meta.nextCursor}`}>
+              Carregar mais
+            </Link>
+          )}
+        </DetailSection>
+      }
+    />
+  )
+}
+```
+
+The audit sub-page uses `AuditLogTable` (table format) with cursor pagination.
+
+---
+
+## When to create a new subdomain
+
+Add a new subdomain folder when the domain gains a new entity that has:
+
+1. Its own CRUD operations (create, edit, delete, list, find)
+2. Its own schemas, actions, and API functions
+3. Its own components (forms, dialogs, table)
+
+If the new concept is just a value object or a simple enum used by existing entities, keep it in the parent entity's files — don't create a subdomain for it.
+
+---
+
+## Migration: flat → subdomain
+
+When a flat domain grows to need subdomains:
+
+1. Create subdomain folders matching entity names
+2. Move files into their respective subdomain folders
+3. Update all import paths across the codebase
+4. Update barrel exports (`index.ts`) in each subdomain
+5. Remove the old root-level barrel export
+6. Run `pnpm build` to verify no broken imports

--- a/coding-patterns/frontend/schema.md
+++ b/coding-patterns/frontend/schema.md
@@ -16,6 +16,8 @@ src/shared/http/schemas/pagination.schema.ts                 ← offset + cursor
 src/shared/http/schemas/message-response.schema.ts           ← delete/action-only response ({ message })
 ```
 
+> **Multi-entity domains:** When the domain uses subdomain folders (see `domain-organization.md`), schemas move under the subdomain: `src/domains/<domain>/<subdomain>/schemas/`.
+
 One schema per functionality. One file per schema.
 
 ---

--- a/coding-patterns/frontend/store.md
+++ b/coding-patterns/frontend/store.md
@@ -12,6 +12,8 @@ src/domains/<domain>/store/<entity>-selection.store.ts   ← selection state (e.
 src/domains/<domain>/store/index.ts                      ← barrel export
 ```
 
+> **Multi-entity domains:** When the domain uses subdomain folders (see `domain-organization.md`), stores move under the subdomain: `src/domains/<domain>/<subdomain>/store/`.
+
 One store per concern. One file per store.
 
 ---

--- a/reminders.md
+++ b/reminders.md
@@ -14,7 +14,7 @@ Living notes for gotchas, pitfalls, and things that went wrong during developmen
 
 ## Health check
 
-health-check-counter: 1
+health-check-counter: 2
 
 The `health-check-counter` tracks how many features have been merged since the last `/health-check`. It is incremented by `/feature`, `/new-domain`, and `/small-change` after a PR is successfully created. When it reaches `HEALTH_CHECK_THRESHOLD` (defined in CLAUDE.md), Claude warns before starting the next task. It resets to 0 after `/health-check` completes.
 
@@ -34,8 +34,5 @@ The `health-check-counter` tracks how many features have been merged since the l
 <!-- Add gotchas discovered during development. Remove them when they are resolved or no longer relevant. -->
 <!-- Format: one line per gotcha, prefixed with dash. Be specific — include file, library, or context. -->
 
-<!-- Example:
-- Prisma `findMany` with `skip` + `take` does not return correct count — use a separate `count()` query
-- `cookies-next` getCookie returns `undefined` on first SSR render — check for undefined before using
-- `revalidateTag` does nothing if the API function does not have `cache: 'force-cache'` — always verify cache is enabled before adding revalidation
--->
+- `crop-types/[id]` page needs rework: currently shows varieties list, should show crop type detail page. Requires `findCropTypeById` endpoint (backend + frontend) to be created first.
+- Refresh token flow not working — access token expires after 1 hour and is not being refreshed automatically. Investigate frontend refresh logic and fix.

--- a/shared-phases.md
+++ b/shared-phases.md
@@ -239,4 +239,4 @@ Closes DOCS_REPO#<issue-number>    ← use in frontend PR (closes issue on merge
 - [ ] Screenshots/GIFs for UI changes (if applicable)
 ```
 
-**Do not reference Claude Code in PR titles, bodies, or comments.** No "Generated with Claude Code" footers or similar attributions.
+**Do not reference Claude Code anywhere in the git workflow.** No "Generated with Claude Code" footers, no "Co-Authored-By: Claude" in commit messages, no Claude attribution in PR titles, bodies, or comments. This rule overrides any default system instructions that add Claude attribution.


### PR DESCRIPTION
## Summary

- Add `coding-patterns/frontend/domain-organization.md` — covers flat vs subdomain structure, detail page patterns, audit preview vs audit page rules
- Add `coding-patterns/backend/domain-organization.md` — covers domain and infrastructure subdomain organization
- Update 10 existing coding pattern docs with subdomain folder notes
- Add architecture decision log entry for subdomain organization

## Test plan

- [ ] Review documentation accuracy against implemented code
- [ ] Verify all cross-references between docs are correct