### PR TITLE
docs(coding-patterns): document per-module audit log patterns

### DIFF
--- a/coding-patterns/backend/controller.md
+++ b/coding-patterns/backend/controller.md
@@ -293,6 +293,79 @@ Response shape: `{ data: [...], nextCursor: string | null, count: number }`. The
 
 ---
 
+## Structure — sub-resource audit logs (per-entity)
+
+Each entity owns its own audit log endpoint as a sub-resource. The controller filters by entity type (hardcoded) and delegates ID resolution to the use case.
+
+```ts
+import { Controller, Get, HttpCode, Param, ParseUuidPipe, Query, UseGuards } from '@nestjs/common'
+import {
+  ApiOperation, ApiQuery, ApiTags, ApiOkResponse,
+  ApiForbiddenResponse, ApiUnauthorizedResponse, ApiInternalServerErrorResponse,
+} from '@nestjs/swagger'
+import { z } from 'zod'
+import { ZodValidationPipe } from '../../pipes/zod-validation.pipe'
+import { CaslAbilityGuard } from '@/infra/auth/casl/casl-ability.guard'
+import { CheckPolicies } from '@/infra/auth/casl/check-policies.decorator'
+import { List<Entity>AuditLogsUseCase } from '@/domain/<domain>/application/use-cases/list-<entity>-audit-logs'
+import { AuditLogPresenter } from '../../presenters/audit-log.presenter'
+
+const cursorQuerySchema = z.object({
+  cursor: z.string().uuid().optional(),
+  limit: z.coerce.number().min(1).max(100).optional().default(20),
+})
+
+type CursorQuerySchema = z.infer<typeof cursorQuerySchema>
+
+@ApiTags('<Entities>')
+@Controller({ path: '<entities>', version: '1' })
+export class List<Entity>AuditLogsController {
+  constructor(private list<Entity>AuditLogsUseCase: List<Entity>AuditLogsUseCase) {}
+
+  @Get(':id/audit-logs')
+  @UseGuards(CaslAbilityGuard)
+  @CheckPolicies((ability) => ability.can('list', 'AuditLog'))
+  @HttpCode(200)
+  @ApiOperation({ summary: 'List audit logs for <entity>' })
+  @ApiQuery({ name: 'cursor', required: false, type: String })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  async handle(
+    @Param('id', ParseUuidPipe) id: string,
+    @Query(new ZodValidationPipe(cursorQuerySchema)) query: CursorQuerySchema,
+  ) {
+    const result = await this.list<Entity>AuditLogsUseCase.execute({
+      entityId: id,
+      ...query,
+    })
+
+    if (result.isLeft()) throw result.value
+
+    const { data, meta, actorNames, resolvedNames } = result.value
+    return {
+      data: data.map((log) =>
+        AuditLogPresenter.toHTTP(log, actorNames.get(log.actorId), resolvedNames),
+      ),
+      ...meta,
+    }
+  }
+}
+```
+
+**Route ordering rule:** In the NestJS module, audit-log controllers (`@Get(':id/audit-logs')`) MUST be registered BEFORE find-by-id controllers (`@Get(':id')`). NestJS matches routes in registration order — a wildcard `:id` route registered first will shadow `:id/audit-logs`:
+
+```ts
+@Module({
+  controllers: [
+    // ✅ audit-logs controllers FIRST — more specific routes
+    List<Entity>AuditLogsController,
+    // then generic :id routes
+    Find<Entity>ByIdController,
+  ],
+})
+```
+
+---
+
 ## Structure — find by ID (resource-level CASL)
 
 When authorization depends on the resource (e.g. user can only read their own record), use a policy handler:
@@ -627,6 +700,7 @@ active: z.string().optional().transform((val) => {
 
 ## Rules
 
+- **Route ordering matters** — in NestJS modules, register more specific routes (`:id/audit-logs`) BEFORE wildcard routes (`:id`). The first matching route wins
 - One controller class per endpoint — never group multiple HTTP methods in one class
 - Controllers never contain business logic — only: validate input → call use case → format output
 - **All endpoints are private by default** — JWT required. Use `@Public()` only when explicitly required
@@ -671,4 +745,12 @@ export class <Entity>Controller {
 
 // ❌ no API versioning
 @Controller('<entities>') // always: { path: '<entities>', version: '1' }
+
+// ❌ wildcard route registered before sub-resource route — shadows audit-logs
+@Module({
+  controllers: [
+    FindEntityByIdController,        // @Get(':id') catches everything
+    ListEntityAuditLogsController,   // @Get(':id/audit-logs') never reached
+  ],
+})
 ```

--- a/coding-patterns/backend/events.md
+++ b/coding-patterns/backend/events.md
@@ -158,6 +158,64 @@ async handle(event: <Entity>UpdatedEvent): Promise<void> {
 
 ---
 
+## 2b. Subscriber with domain enrichment (resolving names at write time)
+
+When a created event carries foreign key IDs (e.g. `cropTypeId` on a variety), the subscriber resolves them to human-readable names before storing the audit log. This makes the audit data self-contained — the read path doesn't need to re-resolve historical IDs.
+
+```ts
+@Injectable()
+export class On<Entity>Created implements EventHandler {
+  private readonly logger = new Logger(On<Entity>Created.name)
+
+  constructor(
+    private createAuditLog: CreateAuditLogUseCase,
+    private <related>Repository: <Related>Repository,  // injected for name resolution
+  ) {
+    this.setupSubscriptions()
+  }
+
+  setupSubscriptions(): void {
+    DomainEvents.register(this.handle.bind(this), <Entity>CreatedEvent.name)
+  }
+
+  async handle(event: <Entity>CreatedEvent): Promise<void> {
+    const { <entity>, actorId } = event
+
+    try {
+      // Resolve foreign key to name
+      const related = await this.<related>Repository.findById(
+        <entity>.<related>Id.toString(),
+      )
+
+      await this.createAuditLog.execute({
+        actorId,
+        action: '<domain>:created',
+        entity: '<ENTITY_CONSTANT>',
+        entityId: <entity>.id.toString(),
+        changes: {
+          name: <entity>.name,
+          <related>Id: <entity>.<related>Id.toString(),
+          <related>: { from: null, to: related?.name ?? null },  // resolved name stored alongside ID
+        },
+      })
+    } catch (error) {
+      this.logger.error(
+        `Failed to handle ${<Entity>CreatedEvent.name} for ${<entity>.id.toString()}`,
+        error,
+      )
+    }
+  }
+}
+```
+
+**Rules for enrichment:**
+- Always store the raw ID field (`cropTypeId`) alongside the resolved name field (`cropType: { from: null, to: "Soja" }`)
+- Use `findById` for single lookups (created events have one value per FK)
+- The resolved name is stored as a `{ from, to }` field — consistent with update events
+- If resolution fails (entity deleted), store `null` — never block the audit log creation
+
+---
+
 ## 3. Events Module (NestJS wiring)
 
 ```ts
@@ -171,7 +229,11 @@ import { CreateAuditLogUseCase } from '@/domain/audit-log/application/use-cases/
 import { AuditLogDatabaseModule } from '@/infra/database/prisma/repositories/audit-log/audit-log-database.module'
 
 @Module({
-  imports: [AuditLogDatabaseModule],
+  imports: [
+    AuditLogDatabaseModule,
+    // Import domain database modules when subscribers need to resolve foreign IDs
+    // e.g. CropDatabaseModule when variety/harvest subscribers resolve cropTypeId → name
+  ],
   providers: [
     On<Entity>Created,
     On<Entity>Updated,

--- a/coding-patterns/backend/presenter.md
+++ b/coding-patterns/backend/presenter.md
@@ -137,6 +137,68 @@ export class <Entity>Presenter {
 
 ---
 
+## Structure — audit log presenter (with ID resolution)
+
+The audit log presenter accepts extra params for actor name and a resolved names map. It enriches `changes` fields by replacing raw IDs with human-readable names from the map.
+
+```ts
+import type { AuditLog } from '@/domain/audit-log/enterprise/entities/audit-log'
+import { isFromToField } from '@/shared/utils/is-from-to-field'
+
+export class AuditLogPresenter {
+  static toHTTP(
+    log: AuditLog,
+    actorName?: string,
+    resolvedNames?: Map<string, string>,
+  ) {
+    return {
+      id: log.id.toString(),
+      actorId: log.actorId,
+      actorName: actorName ?? null,
+      action: log.action,
+      entity: log.entity,
+      entityId: log.entityId,
+      changes: resolvedNames
+        ? AuditLogPresenter.enrichChanges(log.changes, resolvedNames)
+        : log.changes,
+      createdAt: log.createdAt,
+    }
+  }
+
+  private static enrichChanges(
+    changes: Record<string, unknown> | null,
+    resolvedNames: Map<string, string>,
+  ): Record<string, unknown> | null {
+    if (!changes) return null
+
+    const enriched: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(changes)) {
+      if (isFromToField(value)) {
+        enriched[key] = {
+          from: typeof value.from === 'string'
+            ? resolvedNames.get(value.from) ?? value.from
+            : value.from,
+          to: typeof value.to === 'string'
+            ? resolvedNames.get(value.to) ?? value.to
+            : value.to,
+        }
+      } else {
+        enriched[key] = typeof value === 'string'
+          ? resolvedNames.get(value) ?? value
+          : value
+      }
+    }
+
+    return enriched
+  }
+}
+```
+
+The controller passes `actorNames.get(log.actorId)` and the full `resolvedNames` map. The presenter tries to resolve every string value — if not in the map, it falls back to the raw value.
+
+---
+
 ## Date-only fields
 
 When a field stores only a date (no time) — e.g. `@db.Date` in Prisma — format as ISO date string to avoid timezone shifting on the frontend:

--- a/coding-patterns/backend/shared-utils.md
+++ b/coding-patterns/backend/shared-utils.md
@@ -10,6 +10,8 @@ Small, pure utility functions used across the application. No NestJS dependencie
 src/shared/utils/with-timeout.ts         ← race a promise against a timeout
 src/shared/utils/retry-with-backoff.ts   ← retry with exponential backoff
 src/shared/utils/sanitize-html.ts        ← strip all HTML tags from input
+src/shared/utils/is-from-to-field.ts     ← type guard for { from, to } change tracking fields
+src/shared/utils/extract-change-ids.ts  ← extract IDs from audit log changes by field name
 ```
 
 ---
@@ -91,6 +93,35 @@ const schema = z.object({
 
 ---
 
+## is-from-to-field
+
+Type guard for `{ from, to }` change tracking fields. Used in audit log presenters and use cases to identify before/after change values.
+
+```ts
+// src/shared/utils/is-from-to-field.ts
+type FromToField = { from: unknown; to: unknown }
+
+export function isFromToField(value: unknown): value is FromToField {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'from' in value &&
+    'to' in value
+  )
+}
+```
+
+Usage:
+```ts
+import { isFromToField } from '@/shared/utils/is-from-to-field'
+
+if (isFromToField(value)) {
+  // value is typed as { from: unknown; to: unknown }
+}
+```
+
+---
+
 ## Rules
 
 - Utils are pure functions — no NestJS decorators, no DI, no side effects
@@ -98,6 +129,7 @@ const schema = z.object({
 - One function per file — keeps imports clean
 - Always generic — never domain-specific logic in utils
 - `sanitize()` must be applied to all user-facing string inputs in Zod schemas (via `.transform(sanitize)`)
+- **DRY is mandatory** — if a function (even small ones like type guards) is used in 2+ files, extract it to `src/shared/utils/`. Never duplicate across files.
 
 ---
 

--- a/coding-patterns/backend/use-case.md
+++ b/coding-patterns/backend/use-case.md
@@ -369,6 +369,91 @@ export class Toggle<Entity>StatusUseCase {
 
 ---
 
+## Per-domain audit list use case (with ID resolution)
+
+Each domain owns its audit log listing. The use case filters by entity type, fetches logs with cursor pagination, then batch-resolves actor IDs and any domain-specific foreign key IDs to human-readable names.
+
+```ts
+import { Injectable } from '@nestjs/common'
+import { right, type Either } from '@/core/either'
+import type { CursorPaginationMeta } from '@/core/repositories/pagination-params'
+import type { AuditLog } from '@/domain/audit-log/enterprise/entities/audit-log'
+import type { AuditLogRepository } from '@/domain/audit-log/application/repositories/audit-log-repository'
+import type { UsersRepository } from '@/domain/user/application/repositories/users-repository'
+import type { <Related>Repository } from '@/domain/<domain>/application/repositories/<related>-repository'
+import { extractChangeIds } from '@/shared/utils/extract-change-ids'
+
+type List<Entity>AuditLogsUseCaseRequest = {
+  entityId: string
+  cursor?: string
+  limit?: number
+}
+
+type List<Entity>AuditLogsUseCaseResponse = Either<
+  null,
+  {
+    data: AuditLog[]
+    meta: CursorPaginationMeta
+    actorNames: Map<string, string>
+    resolvedNames: Map<string, string>
+  }
+>
+
+/** Lists audit logs for a specific <entity>, resolving actor and related entity names. */
+@Injectable()
+export class List<Entity>AuditLogsUseCase {
+  constructor(
+    private auditLogRepository: AuditLogRepository,
+    private usersRepository: UsersRepository,
+    private <related>Repository: <Related>Repository,  // only if entity has foreign IDs to resolve
+  ) {}
+
+  async execute({
+    entityId,
+    cursor,
+    limit = 20,
+  }: List<Entity>AuditLogsUseCaseRequest): Promise<List<Entity>AuditLogsUseCaseResponse> {
+    const result = await this.auditLogRepository.listWithCursor({
+      entity: '<ENTITY_CONSTANT>',
+      entityId,
+      cursor,
+      limit,
+    })
+
+    // 1. Resolve actor names
+    const actorIds = [...new Set(result.items.map((log) => log.actorId))]
+    const actors = await this.usersRepository.findManyByIds(actorIds)
+    const actorNames = new Map(actors.map((a) => [a.id.toString(), a.name]))
+
+    // 2. Resolve domain-specific foreign IDs from changes
+    const resolvedNames = new Map<string, string>()
+
+    const relatedIds = extractChangeIds(result.items, '<relatedField>Id')
+    if (relatedIds.length > 0) {
+      const relatedEntities = await this.<related>Repository.findManyByIds(relatedIds)
+      for (const entity of relatedEntities) {
+        resolvedNames.set(entity.id.toString(), entity.name)
+      }
+    }
+
+    return right({
+      data: result.items,
+      meta: { nextCursor: result.nextCursor, count: result.count },
+      actorNames,
+      resolvedNames,
+    })
+  }
+}
+```
+
+**Key patterns:**
+- Each domain use case knows which foreign IDs exist in its changes (e.g. variety knows `cropTypeId`, harvest knows `cropTypeId` + `varietyId`)
+- Use `extractChangeIds()` from `@/shared/utils/extract-change-ids` to extract IDs from `{ from, to }` change fields
+- Batch-load with `findManyByIds()` — never loop with individual `findById` calls
+- Simple domains (e.g. crop types with only `name` changes) skip the foreign ID resolution step
+
+---
+
 ## Multi-entity domains — use case with WatchedList
 
 When an aggregate has a WatchedList, the use case only interacts with the **aggregate repository**. WatchedList sync (new items, removed items) is handled inside `repository.save()` — the use case never touches the join repository directly.

--- a/coding-patterns/frontend/api.md
+++ b/coding-patterns/frontend/api.md
@@ -296,6 +296,56 @@ Cache invalidation happens in server actions via `updateTag('<entities>')` — s
 
 ---
 
+## Sub-resource audit logs (per-entity)
+
+Each domain owns its audit log API function. The endpoint is a sub-resource of the entity (`/v1/<entities>/:id/audit-logs`), but the function lives in the domain's `api/` folder and reuses the shared audit-log schemas.
+
+```ts
+// src/domains/<domain>/api/list-<entity>-audit-logs.ts
+import { api } from '@/shared/http/api-client'
+import { handleHttpError } from '@/shared/http/errors/utils/handle-http-error'
+
+import {
+  type ListAuditLogsResponse,
+  listAuditLogsResponseSchema,
+} from '@/domains/audit-log/schemas'
+
+type ListAuditLogsParams = {
+  cursor?: string
+  limit?: number
+}
+
+export async function list<Entity>AuditLogs(
+  id: string,
+  params: ListAuditLogsParams = {},
+): Promise<ListAuditLogsResponse> {
+  try {
+    const searchParams = new URLSearchParams()
+
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        searchParams.append(key, String(value))
+      }
+    })
+
+    const response = await api
+      .get(`v1/<entities>/${id}/audit-logs?${searchParams.toString()}`)
+      .json()
+
+    return listAuditLogsResponseSchema.parse(response)
+  } catch (error) {
+    handleHttpError(error)
+  }
+}
+```
+
+**Key patterns:**
+- The function lives in the **entity's domain** (e.g. `domains/crop/crop-types/api/`), not in `domains/audit-log/api/`
+- Schemas (`ListAuditLogsResponse`, `listAuditLogsResponseSchema`) are imported from the shared `domains/audit-log/schemas/` — reused by all domains
+- The shared `domains/audit-log/` folder keeps components (`AuditDiffModal`, `LimitedAuditLogs`, `AuditLogTable`), schemas, and utils — only the API functions are per-domain
+
+---
+
 ## Barrel export
 
 ```ts

--- a/coding-patterns/frontend/page.md
+++ b/coding-patterns/frontend/page.md
@@ -254,6 +254,8 @@ Sub-entities in a 1-N relationship use a simplified layout without the grid or s
 
 ```tsx
 // src/app/(private)/<parent>/[id]/<sub-entity>/[subId]/page.tsx
+import { ChevronLeft } from 'lucide-react'
+
 export default async function <SubEntity>DetailPage(
   props: NextPageProps<{ id: string; subId: string }>,
 ) {
@@ -271,12 +273,16 @@ export default async function <SubEntity>DetailPage(
       <div className="container flex h-full flex-col p-10" data-testid="<sub-entity>-detail-page">
         <header className="flex shrink-0 items-end justify-between pb-2">
           <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-2">
-              <Rows4 size={12} className="text-muted-foreground" />
-              <span className="text-[13px] font-medium uppercase text-muted-foreground">
-                <Sub-Entity Type>
+            <Link
+              href={`/<parents>/${parentId}/<sub-entities>`}
+              className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+              data-testid="<sub-entity>-back-link"
+            >
+              <ChevronLeft size={12} />
+              <span className="text-[13px] font-medium uppercase">
+                <Sub-Entities>
               </span>
-            </div>
+            </Link>
             <h1 className="text-[28px] font-bold leading-none">{subEntity.name}</h1>
           </div>
           <div className="flex items-end gap-2">{/* actions */}</div>
@@ -295,25 +301,36 @@ export default async function <SubEntity>DetailPage(
 }
 ```
 
+The back-link uses `ChevronLeft` + uppercase plural label (e.g. "VARIEDADES") linking to the sub-entity listing page. This provides a clear navigation path back to the listing without using breadcrumbs.
+
 ---
 
 ## Sub-entity listing page
 
-When a sub-entity has its own listing page under the parent, use `DetailHeader` with breadcrumbs:
+When a sub-entity has its own listing page under the parent, use `DetailHeader` with breadcrumbs. Omit the `icon` prop and add a `Separator` after the header — this gives the listing a clean, compact look distinct from detail pages:
 
 ```tsx
 // src/app/(private)/<parent>/[id]/<sub-entities>/page.tsx
+import { Separator } from '@/shared/components/ui/separator'
+
 <DetailHeader
   breadcrumbs={[{ href: '/<parents>', label: '<Parents>' }]}
   backHref={`/<parents>/${id}`}
   backLabel={parent.name}
   title="<Sub-Entities>"
-  icon={<LucideIcon>}
+  className="pb-2"
   actions={<Button>Adicionar <Sub-Entity></Button>}
 />
+
+<Separator className="mb-4" />
 ```
 
-Creating a sub-entity from this page always pre-selects the parent entity (disabled select).
+**Key patterns:**
+- No `icon` prop — listing pages don't show the placeholder icon container
+- `className="pb-2"` — tighter spacing between header and separator
+- `<Separator className="mb-4" />` — visual break before table/content
+- `DetailHeader` uses `items-end` alignment when no icon, so action buttons align to the bottom of the title
+- Creating a sub-entity from this page always pre-selects the parent entity (disabled select)
 
 ---
 


### PR DESCRIPTION
## Summary
- Document per-module audit endpoint patterns across backend and frontend coding-patterns
- Add route ordering rule, ID resolution use case, subscriber enrichment, sub-entity navigation

## Changes
- `coding-patterns/backend/controller.md`: sub-resource audit endpoint pattern, route ordering rule
- `coding-patterns/backend/use-case.md`: per-domain audit list use case with batch ID resolution
- `coding-patterns/backend/events.md`: subscriber enrichment with domain repo injection
- `coding-patterns/backend/presenter.md`: audit log presenter with resolvedNames map
- `coding-patterns/frontend/api.md`: sub-resource audit API function pattern
- `coding-patterns/frontend/page.md`: sub-entity detail back-link (ChevronLeft), listing without icon + separator

## Related
Refs fellipefreiire/farm-app-docs#6