### PR TITLE
docs: update harvest flows, api reference, and reminders

### DIFF
--- a/api-reference.md
+++ b/api-reference.md
@@ -132,11 +132,11 @@ If the project uses WebSockets or Server-Sent Events, document them in a separat
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| POST | /v1/harvests | Create a new harvest | Private |
-| GET | /v1/harvests | List harvests (paginated) | Private |
+| POST | /v1/harvests | Create a new harvest (name, cropTypeId, varietyId, fieldId, dates) | Private |
+| GET | /v1/harvests | List harvests (paginated, filterable by query, status, cropTypeId, fieldId) | Private |
 | GET | /v1/harvests/:id | Find harvest by ID | Private |
 | GET | /v1/harvests/active | Get active harvest by field | Private |
-| PUT | /v1/harvests/:id | Edit a harvest | Private |
+| PUT | /v1/harvests/:id | Edit a harvest (name, cropTypeId, varietyId, fieldId, dates) | Private |
 | DELETE | /v1/harvests/:id | Delete a harvest | Private |
 | PATCH | /v1/harvests/:id/activate | Activate a harvest | Private |
 | PATCH | /v1/harvests/:id/complete | Complete a harvest | Private |

--- a/flows.md
+++ b/flows.md
@@ -229,10 +229,27 @@ sequenceDiagram
 **Actor:** Farm owner, Farm manager
 **Domain:** Crop (Harvest subdomain)
 
+**Listing:**
+1. User navigates to "Colheitas" → paginated table with columns: Nome, Status (badge), Tipo de Cultura, Variedade, Talhão, Data de Início, Previsão de Término
+2. Tabs filter by status: Todos, Planejadas, Ativas, Concluídas, Canceladas
+3. Search input filters by nome (debounced, server-side)
+4. Filters popover allows filtering by Tipo de Cultura, Variedade (dependent on crop type), Talhão — active filters shown as removable tags below the search bar
+
 **Create:**
-1. User clicks "Nova colheita" → form opens
-2. User fills: field, variety, planting date, expected harvest date → submits
-3. System creates harvest with status `PLANNED` → audit log records creation
+1. User clicks "Adicionar Colheita" → sheet opens
+2. User fills: nome, tipo de cultura (async select), variedade (async select, dependent), talhão (async select), data de início, previsão de término → submits
+3. System validates (variety belongs to crop type, no active harvest on field, valid date range) → creates harvest with status `PLANNED` → audit log records creation
+
+**Edit:**
+1. User opens harvest detail → clicks "Editar Colheita" → sheet opens
+2. User can edit: nome, tipo de cultura, variedade, talhão, datas
+3. System updates harvest → audit log records all changed fields (name, cropTypeId, varietyId, fieldId, dates)
+4. Sheet closes automatically on success
+
+**Detail page:**
+- Header: nome + status badge
+- Sidebar "Detalhes" (collapsible, shows first 4): Tipo de Cultura (link), Variedade (link), Talhão (link), Data de Início, Previsão de Término, Data de Término (if completed), Criado em, Atualizado em
+- Main: Auditoria (last 5 logs with diff modal)
 
 **Activate:**
 1. User clicks "Iniciar" on a planned harvest

--- a/reminders.md
+++ b/reminders.md
@@ -14,7 +14,7 @@ Living notes for gotchas, pitfalls, and things that went wrong during developmen
 
 ## Health check
 
-health-check-counter: 0
+health-check-counter: 1
 
 The `health-check-counter` tracks how many features have been merged since the last `/health-check`. It is incremented by `/feature`, `/new-domain`, and `/small-change` after a PR is successfully created. When it reaches `HEALTH_CHECK_THRESHOLD` (defined in CLAUDE.md), Claude warns before starting the next task. It resets to 0 after `/health-check` completes.
 
@@ -36,4 +36,6 @@ The `health-check-counter` tracks how many features have been merged since the l
 
 - Phase 4 doc updates were skipped in past sessions, causing `api-reference.md`, `flows.md`, and `architecture.md` to go stale. Every implementation MUST update the docs listed in Phase 4 (`shared-phases.md` lines 88-95) — never skip even for small changes.
 - `.env.test` must NOT contain `DATABASE_URL` — it breaks E2E tests because NestJS `ConfigModule` uses it instead of the unique schema URL set by `setup-e2e.ts`.
+- Redis cache can serve stale data after schema migrations. When adding new fields to an entity, flush Redis (`redis-cli FLUSHDB`) after migration. The `findById` repository method caches full entities — cached entries from before the migration won't have the new field.
+- Frontend toast/UI strings must be in Portuguese. Backend API responses stay in English (per CLAUDE.md rule). The translation happens in the frontend action files and components, not in the backend.
 


### PR DESCRIPTION
## Summary
- Update harvest lifecycle flow with listing, filtering, search, and detail page
- Update API reference with harvest query params and editable fields
- Add gotchas: Redis cache after migration, Portuguese UI strings rule
- Increment health-check-counter

Closes #13