### PR TITLE
docs: add QueryBus coding pattern and update cross-domain rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,10 +52,11 @@ SETTINGS_FILE          = .claude/settings.json               ← symlink to docs
 
 ```
 src/
-  core/                        ← shared primitives (Entity, ValueObject, Either, UniqueEntityId, DomainEvent)
+  core/                        ← shared primitives (Entity, ValueObject, Either, UniqueEntityId, DomainEvent, QueryBus)
     entities/
     errors/
     events/
+    query-bus/                 ← QueryBus (cross-domain request/reply, see coding-patterns/backend/query-bus.md)
     repositories/
     types/
   domain/
@@ -68,6 +69,8 @@ src/
           __tests__/
           errors/              ← domain-specific use case errors
         repositories/          ← repository interfaces (I<Domain>Repository)
+        queries/               ← QueryBus query contracts (cross-domain data access)
+        handlers/              ← QueryBus handlers (respond to queries from other domains)
         subscribers/           ← cross-domain event subscribers (if needed)
     <domain>/                    ← subdomain folders for multi-entity domains (see coding-patterns/backend/domain-organization.md)
       <subdomain>/
@@ -96,6 +99,7 @@ src/
       dtos/                    ← request/response DTOs
     events/
       <domain>/                ← event subscribers wired to NestJS
+    query-bus/                 ← QueryBusModule (@Global, wires all query handlers)
     auth/                      ← JWT + CASL authorization
     cache/                     ← Redis cache
     logger/                    ← Winston logger
@@ -108,6 +112,7 @@ test/                          ← shared test helpers (outside src/)
   factories/                   ← entity factories for test setup
   repositories/
     <domain>/                  ← InMemory repository implementations
+  query-bus/                   ← InMemoryQueryBus for unit tests
   cache/                       ← in-memory cache stub
   cryptography/                ← fake cryptography for tests
   utils/                       ← test utility functions
@@ -200,7 +205,7 @@ claude --add-dir ./backend --add-dir ./frontend
 | 5 | Resilience | Either<Error, { data: ... }> in use cases |
 | 6 | Quality | AAA pattern in tests, InMemoryRepository for unit tests, low cyclomatic complexity |
 | 7 | Data | Versioned Prisma migrations, mappers (toDomain/toPrisma), constraints (FK, unique). Always run `prisma migrate dev` after any schema change — database is always local. |
-| 8 | Events | Cross-module communication via Domain Events, typed contracts |
+| 8 | Events | Cross-module side effects via Domain Events (fire-and-forget), cross-module data queries via QueryBus (request/reply). Use cases never import repositories from other domains. |
 | 9 | Secrets | Never commit `.env` files — must be in `.gitignore`. Never hardcode credentials, tokens or secrets in code. Environment variables always read from `process.env`. If a new env var is needed, add it to `.env.example` with a placeholder value. |
 | 10 | Accessibility | Semantic HTML elements (`button`, `nav`, `main`, `section`, not generic `div`). All interactive elements must be keyboard-navigable. Form inputs must have associated `label` elements. Images must have `alt` text. ARIA attributes only when semantic HTML is insufficient. |
 | 11 | Logging | Winston structured JSON. Levels: `error` (unrecoverable failures — needs human attention), `warn` (recoverable issues — retries, fallbacks, cache misses), `info` (business events — entity created, payment processed), `debug` (technical details — disabled in production via `LOG_LEVEL`). Required fields: `level`, `message`, `domain`, `timestamp`. Optional: `entityId`, `actorId`, `error`. Domain layer never logs. Use cases never log directly. Controllers log `error`/`warn`. Event subscribers log `error`/`info`. Never log passwords, tokens, PII, or full request bodies. Never use `console.log` in production code. |

--- a/architecture.md
+++ b/architecture.md
@@ -60,6 +60,7 @@ graph TD
 - User is cross-cutting — every non-public endpoint requires authentication and authorization
 - Audit subscribes to domain events from all domains — never called directly
 - Schedule drives Harvest lifecycle: ScheduleActivatedEvent → Harvest becomes ACTIVE, ScheduleCancelledEvent → Harvest reverts to UNSCHEDULED
+- Solid arrows represent data dependencies resolved at runtime via QueryBus (see `coding-patterns/backend/query-bus.md`). Use cases never import repositories from other domains — they use typed query contracts instead
 - Relationships for planned domains are preliminary and will be refined during implementation
 
 ---
@@ -81,6 +82,7 @@ None in MVP. Infrastructure decisions deferred to post-MVP.
 | **Caching** | Redis for frequently accessed read-only data. Cache invalidation via domain events. |
 | **Logging** | Winston with structured JSON. Domain layer never logs. Controllers log error/warn. Event subscribers log error/info. |
 | **Audit** | Every mutation emits a domain event consumed by the Audit subscriber. Stores actor, action, entity, timestamp, before/after snapshot. |
+| **Cross-domain queries** | QueryBus — static in-process request/reply bus (see `coding-patterns/backend/query-bus.md`). Use cases query other domains via typed query contracts instead of importing their repositories. Subscribers are exempt — they bridge domains directly. Designed to swap to a message broker for microservice migration. |
 | **Pagination** | Mandatory on all listing endpoints. |
 | **Multi-tenancy** | Not implemented in MVP. No design decisions that block future migration (avoid hardcoded single-tenant assumptions). |
 
@@ -108,6 +110,14 @@ None in MVP. Infrastructure decisions deferred to post-MVP.
 ---
 
 ## Decision Log
+
+### 2026-03-17 — QueryBus for cross-domain data queries
+
+**Context:** Health-check detected 18 module boundary violations: use cases importing repositories and error classes from other domains. As the system moves toward microservices, each domain must be independently deployable. Direct repository imports create tight coupling that blocks extraction.
+**Decision:** Introduce a QueryBus — a static in-process request/reply bus in `src/core/query-bus/`. Query contracts (pure data types) live in the responding domain's `application/queries/`. Handlers self-register at NestJS startup via `QueryBusModule` (`@Global`). Use cases call `QueryBus.execute()` instead of injecting cross-domain repositories. Error classes that reference other domains are duplicated locally.
+**Options considered:** (A) QueryBus in core with typed contracts (chosen) / (B) Shared service layer between domains / (C) Event sourcing with projections
+**Rationale:** Option A mirrors the existing DomainEvents pattern (static class, self-registering handlers), requires zero database changes, and maps directly to a message broker for microservice migration. Option B creates a new coupling layer. Option C is overengineered for MVP.
+**Consequences:** 21 use cases refactored (11 group A + 10 audit logs). 5 query contracts, 5 handlers, 3 local error classes created. HTTP modules no longer import cross-domain database modules (QueryBusModule is global). Subscribers remain exempt — they are the intended cross-domain bridge. New coding pattern documented at `docs/coding-patterns/backend/query-bus.md`.
 
 ### 2026-03-10 — Subdomain folders for multi-entity domains
 

--- a/coding-patterns/backend/events.md
+++ b/coding-patterns/backend/events.md
@@ -2,6 +2,8 @@
 
 Domain events decouple state changes from their side effects. The entity emits the event; subscribers react to it in separate modules.
 
+> **DomainEvents vs QueryBus:** DomainEvents are fire-and-forget (one-way, no return value) — used for side effects after mutations. QueryBus is request/reply (returns data) — used when a use case needs to read data from another domain. See `query-bus.md` for the full QueryBus pattern.
+
 ---
 
 ## File locations

--- a/coding-patterns/backend/query-bus.md
+++ b/coding-patterns/backend/query-bus.md
@@ -1,0 +1,408 @@
+# QueryBus Pattern
+
+The QueryBus is an in-process request/reply mechanism for cross-domain data lookups. It decouples use cases from other domains' repositories while keeping the query synchronous. When migrating to microservices, the static bus becomes a broker (Kafka, RabbitMQ) — zero application code changes.
+
+---
+
+## When to use
+
+| Need | Solution |
+|------|----------|
+| Use case needs data **from another domain** (e.g., schedule needs harvest dates) | **QueryBus** |
+| Use case needs data **from its own domain** (e.g., purchase needs inventory inputs) | **Direct repository injection** |
+| Side effect after mutation (e.g., audit log after entity created) | **DomainEvents** (see `events.md`) |
+| Subscriber reacting to another domain's event | **Direct repository import** (subscribers are the cross-domain bridge) |
+
+**Rule of thumb:** Use cases never import repositories or error classes from other domains. Subscribers can.
+
+---
+
+## File locations
+
+```
+src/core/query-bus/query.ts                          ← Query interface
+src/core/query-bus/query-handler.ts                  ← QueryHandler interface
+src/core/query-bus/query-bus.ts                      ← Static QueryBus class
+
+src/domain/<domain>/<subdomain>/application/queries/<query-name>.query.ts   ← query contract + result type
+src/domain/<domain>/<subdomain>/application/handlers/<query-name>.handler.ts ← handler implementation
+src/domain/<domain>/<subdomain>/application/handlers/__tests__/<query-name>.handler.spec.ts ← handler test
+
+src/infra/query-bus/query-bus.module.ts              ← NestJS wiring (@Global)
+
+test/query-bus/in-memory-query-bus.ts                ← test helper
+```
+
+> **Flat domains** omit the `<subdomain>` level: `src/domain/<domain>/application/queries/`.
+
+---
+
+## Core primitives
+
+The three files in `src/core/query-bus/` follow the same static-class pattern as `DomainEvents`:
+
+```ts
+// query.ts
+export interface Query {
+  readonly queryName: string
+}
+
+// query-handler.ts
+export interface QueryHandler<TQuery extends Query = Query, TResult = unknown> {
+  handle(query: TQuery): Promise<TResult>
+}
+
+// query-bus.ts
+export class QueryBus {
+  private static handlersMap: Record<string, (query: Query) => Promise<unknown>> = {}
+
+  public static register(queryName: string, handler: (query: Query) => Promise<unknown>): void
+  public static async execute<TResult>(query: Query): Promise<TResult>
+  public static clearHandlers(): void
+}
+```
+
+**Comparison with DomainEvents:**
+
+| Aspect | DomainEvents | QueryBus |
+|--------|-------------|----------|
+| Direction | Fire-and-forget (one-way) | Request/reply (returns data) |
+| Trigger | Entity emits after mutation | Use case calls when it needs data |
+| Handlers | Multiple per event | One per query |
+| Return | `void` | `Promise<TResult>` |
+| Registration | By event class name | By query name string |
+
+---
+
+## 1. Query contract
+
+The query contract defines the request shape and the result type. It lives in the **responding** domain (the domain that owns the data). This is a pure data contract — no business logic, no dependencies.
+
+```ts
+// src/domain/<domain>/application/queries/<query-name>.query.ts
+import type { Query } from '@/core/query-bus/query'
+
+export type Find<Entity>QueryResult = {
+  id: string
+  name: string
+  // only the fields the consumer needs — never the full entity
+} | null
+
+export class Find<Entity>Query implements Query {
+  readonly queryName = 'Find<Entity>Query'
+
+  constructor(public readonly <entity>Id: string) {}
+}
+```
+
+**Rules for query contracts:**
+- Result type is a plain object or `null` — never a domain entity
+- Include only the fields consumers need — this is the anti-corruption layer
+- IDs are always `string` (not `UniqueEntityID`)
+- Dates stay as `Date`
+- The `queryName` must be unique across the entire application
+- The file exports both the class and the result type (consumers import both)
+
+**Naming convention:**
+- `Find<Entity>Query` — find by ID, returns single or null
+- `FindActive<Entity>Query` — find only active/non-deleted, returns single or null
+- `Find<Entity>sByIdsQuery` — batch lookup, returns array
+
+---
+
+## 2. Handler
+
+The handler lives in the same domain as the query. It injects the domain's repository and maps the entity to the query result type.
+
+```ts
+// src/domain/<domain>/application/handlers/<query-name>.handler.ts
+import { Injectable } from '@nestjs/common'
+import { QueryBus } from '@/core/query-bus/query-bus'
+import type { QueryHandler } from '@/core/query-bus/query-handler'
+import { <Entity>Repository } from '../repositories/<entity>-repository'
+import { Find<Entity>Query, type Find<Entity>QueryResult } from '../queries/<query-name>.query'
+
+@Injectable()
+export class Find<Entity>Handler
+  implements QueryHandler<Find<Entity>Query, Find<Entity>QueryResult>
+{
+  constructor(private <entity>Repository: <Entity>Repository) {
+    QueryBus.register('Find<Entity>Query', this.handle.bind(this))
+  }
+
+  async handle(query: Find<Entity>Query): Promise<Find<Entity>QueryResult> {
+    const entity = await this.<entity>Repository.findById(query.<entity>Id)
+
+    if (!entity) return null
+
+    return {
+      id: entity.id.toString(),
+      name: entity.name,
+    }
+  }
+}
+```
+
+**Rules for handlers:**
+- `@Injectable()` — registered as NestJS provider
+- Self-registers in constructor via `QueryBus.register()` — same pattern as event subscribers
+- Maps entity to plain result type — never returns the entity directly
+- One handler per query — never reuse handlers across queries
+- Handler and query live in the same domain (the data owner)
+
+---
+
+## 3. QueryBus Module (NestJS wiring)
+
+```ts
+// src/infra/query-bus/query-bus.module.ts
+import { Global, Module } from '@nestjs/common'
+import { CropDatabaseModule } from '@/infra/database/prisma/repositories/crop/crop-database.module'
+// ... other database modules
+import { Find<Entity>Handler } from '@/domain/<domain>/application/handlers/<query-name>.handler'
+
+@Global()
+@Module({
+  imports: [
+    // Database modules for domains that provide handlers
+    CropDatabaseModule,
+  ],
+  providers: [
+    // All query handlers
+    Find<Entity>Handler,
+  ],
+})
+export class QueryBusModule {}
+```
+
+**Rules:**
+- `@Global()` — handlers must be instantiated at startup to self-register
+- Imported in `AppModule` — alongside `EventsModule`
+- Each database module is imported once — even if it provides multiple handlers
+- When adding a new handler: add the provider here and import its database module if not already imported
+
+---
+
+## 4. Using QueryBus in a use case
+
+```ts
+import { Injectable } from '@nestjs/common'
+import { QueryBus } from '@/core/query-bus/query-bus'
+import { Find<Entity>Query, type Find<Entity>QueryResult }
+  from '@/domain/<other-domain>/application/queries/<query-name>.query'
+import { <Entity>NotFoundError } from './errors/<entity>-not-found-error'
+
+@Injectable()
+export class MyUseCase {
+  constructor(
+    private myRepository: MyRepository,
+    // no cross-domain repository here — QueryBus is static
+  ) {}
+
+  async execute(request: Request): Promise<Response> {
+    const result = await QueryBus.execute<Find<Entity>QueryResult>(
+      new Find<Entity>Query(request.<entity>Id),
+    )
+
+    if (!result) {
+      return left(new <Entity>NotFoundError(request.<entity>Id))
+    }
+
+    // Use result.id, result.name, etc.
+  }
+}
+```
+
+**Key points:**
+- `QueryBus` is static — no constructor injection needed
+- Import the **query class** and **result type** from the other domain's `queries/` folder
+- These imports are allowed because query files are pure contracts (no dependencies)
+- Error classes must be **local** — never import errors from another domain
+
+---
+
+## 5. Local error classes
+
+When a use case needs an error for an entity from another domain, create a local copy:
+
+```ts
+// src/domain/schedule/application/use-cases/errors/harvest-not-found-error.ts
+import { BaseError } from '@/core/errors/base-error'
+
+export class HarvestNotFoundError extends BaseError {
+  constructor(identifier: string) {
+    super(`Harvest "${identifier}" not found.`, 'HarvestNotFoundError')
+  }
+}
+```
+
+The error `name` must match the original — error filters map by `exception.name`, so the HTTP status mapping continues to work without changes.
+
+---
+
+## Existing queries
+
+| Query | Domain | Result type | Used by |
+|-------|--------|-------------|---------|
+| `FindHarvestQuery` | crop/harvests | `{ id, status, startDate, expectedEndDate } \| null` | schedule use cases (9) |
+| `FindActiveInputQuery` | inventory/inputs | `{ id, name, active } \| null` | schedule use cases (3) |
+| `FindInputQuery` | inventory/inputs | `{ id, name } \| null` | edit-schedule-operation-input |
+| `FindActiveSupplierQuery` | supplier | `{ id, active } \| null` | inventory/purchases use cases (2) |
+| `FindUsersByIdsQuery` | user | `{ id, name }[]` | all audit log use cases (10) |
+
+---
+
+## Testing
+
+### Handler tests
+
+Test the handler directly with an InMemory repository:
+
+```ts
+import { beforeEach, describe, expect, it } from 'vitest'
+import { InMemory<Entity>Repository } from 'test/repositories/<domain>/in-memory-<entity>-repository'
+import { make<Entity> } from 'test/factories/make-<entity>'
+import { Find<Entity>Handler } from '../<query-name>.handler'
+import { Find<Entity>Query } from '../../queries/<query-name>.query'
+
+let sut: Find<Entity>Handler
+let repository: InMemory<Entity>Repository
+
+describe('Find<Entity>Handler', () => {
+  beforeEach(() => {
+    repository = new InMemory<Entity>Repository()
+    sut = new Find<Entity>Handler(repository)
+  })
+
+  it('should return data when entity exists', async () => {
+    const entity = make<Entity>()
+    repository.items.push(entity)
+
+    const result = await sut.handle(new Find<Entity>Query(entity.id.toString()))
+
+    expect(result).toEqual({
+      id: entity.id.toString(),
+      name: entity.name,
+    })
+  })
+
+  it('should return null when entity does not exist', async () => {
+    const result = await sut.handle(new Find<Entity>Query('non-existent'))
+
+    expect(result).toBeNull()
+  })
+})
+```
+
+### Use case tests with InMemoryQueryBus
+
+Use cases that call `QueryBus.execute()` need query responses registered in tests:
+
+```ts
+import { InMemoryQueryBus } from 'test/query-bus/in-memory-query-bus'
+
+let queryBus: InMemoryQueryBus
+
+describe('My Use Case', () => {
+  beforeEach(() => {
+    queryBus = new InMemoryQueryBus()
+    // Register static response for the query
+    queryBus.register('FindHarvestQuery', {
+      id: 'harvest-1',
+      status: 'UNSCHEDULED',
+      startDate: new Date('2026-01-01'),
+      expectedEndDate: new Date('2026-06-30'),
+    })
+
+    sut = new MyUseCase(myRepository)
+  })
+
+  afterEach(() => {
+    queryBus.clear()
+  })
+
+  it('should return error when entity not found', async () => {
+    // Override for this specific test
+    queryBus.register('FindHarvestQuery', null)
+
+    const result = await sut.execute({ ... })
+
+    expect(result.isLeft()).toBe(true)
+  })
+})
+```
+
+**For tests that need different responses per ID** (e.g., copy-schedule queries two different harvests), register a dynamic handler directly:
+
+```ts
+import { QueryBus } from '@/core/query-bus/query-bus'
+
+const harvestsMap = new Map<string, FindHarvestQueryResult>()
+
+beforeEach(() => {
+  QueryBus.register('FindHarvestQuery', async (query: any) => {
+    return harvestsMap.get(query.harvestId) ?? null
+  })
+})
+
+// In test:
+harvestsMap.set('harvest-1', { id: 'harvest-1', status: 'ACTIVE', ... })
+harvestsMap.set('harvest-2', { id: 'harvest-2', status: 'UNSCHEDULED', ... })
+```
+
+---
+
+## Adding a new query
+
+When a use case needs data from another domain:
+
+1. **Check if a query already exists** — see the table above
+2. **Create the query contract** in the responding domain's `application/queries/`
+3. **Create the handler** in the responding domain's `application/handlers/`
+4. **Write handler tests** in `application/handlers/__tests__/`
+5. **Register the handler** in `QueryBusModule` (add provider + import database module if needed)
+6. **Refactor the use case** — replace repository import with `QueryBus.execute()`, create local error class if needed
+7. **Update use case tests** — replace InMemory repository with InMemoryQueryBus
+8. **Update HTTP module** — remove the cross-domain database module import (QueryBusModule is `@Global`)
+9. **Update error filter** — change import path to local error class (if error name is unchanged, no switch-case change needed)
+
+---
+
+## Module boundary rules
+
+| Import | Allowed in use cases? | Allowed in subscribers? |
+|--------|----------------------|------------------------|
+| Repository from own domain | Yes | Yes |
+| Repository from other domain | **No** — use QueryBus | Yes (subscribers bridge domains) |
+| Error class from other domain | **No** — create local copy | Yes |
+| Query contract from other domain | Yes (pure data, no deps) | N/A |
+| `AuditLogRepository` (shared service) | Yes | Yes |
+
+---
+
+## Anti-patterns
+
+```ts
+// ❌ importing repository from another domain in a use case
+import { HarvestsRepository } from '@/domain/crop/harvests/application/repositories/harvests-repository'
+
+// ❌ importing error from another domain in a use case
+import { HarvestNotFoundError } from '@/domain/crop/harvests/application/use-cases/errors/harvest-not-found-error'
+
+// ❌ returning domain entity from query handler
+async handle(query: FindHarvestQuery) {
+  return this.harvestsRepository.findById(query.harvestId) // never return entity
+}
+
+// ❌ injecting QueryBus in constructor (it's static)
+constructor(private queryBus: QueryBus) {} // no — use QueryBus.execute() directly
+
+// ❌ putting business logic in query handler
+async handle(query: FindHarvestQuery) {
+  const harvest = await this.harvestsRepository.findById(query.harvestId)
+  if (harvest.status !== 'ACTIVE') throw new Error('...') // handler only maps data
+}
+
+// ❌ using QueryBus for same-domain lookups
+const input = await QueryBus.execute(new FindInputQuery(id)) // just inject InputsRepository
+```

--- a/coding-patterns/backend/tests.md
+++ b/coding-patterns/backend/tests.md
@@ -399,6 +399,68 @@ describe('Toggle <Entity> Status', () => {
 - Use `result.isRight()` / `result.isLeft()` — never access `.value` before checking
 - Assert both the return value AND the repository state when relevant
 
+### Use case tests with QueryBus (cross-domain data)
+
+When a use case calls `QueryBus.execute()` instead of injecting a cross-domain repository, tests use `InMemoryQueryBus` to register static responses:
+
+```ts
+import { InMemoryQueryBus } from 'test/query-bus/in-memory-query-bus'
+
+let queryBus: InMemoryQueryBus
+
+describe('Use Case with QueryBus', () => {
+  beforeEach(() => {
+    queryBus = new InMemoryQueryBus()
+    // Register default response for cross-domain query
+    queryBus.register('FindHarvestQuery', {
+      id: 'harvest-1',
+      status: 'UNSCHEDULED',
+      startDate: new Date('2026-01-01'),
+      expectedEndDate: new Date('2026-06-30'),
+    })
+
+    sut = new MyUseCase(myRepository)  // no cross-domain repo in constructor
+  })
+
+  afterEach(() => {
+    queryBus.clear()
+  })
+
+  it('should return error when cross-domain entity not found', async () => {
+    queryBus.register('FindHarvestQuery', null)  // override for this test
+    const result = await sut.execute({ ... })
+    expect(result.isLeft()).toBe(true)
+  })
+})
+```
+
+For tests querying **multiple entities by ID** (e.g., copy-schedule with source + target harvests), register a dynamic handler:
+
+```ts
+import { QueryBus } from '@/core/query-bus/query-bus'
+
+const harvestsMap = new Map<string, FindHarvestQueryResult>()
+
+beforeEach(() => {
+  QueryBus.register('FindHarvestQuery', async (query: any) => {
+    return harvestsMap.get(query.harvestId) ?? null
+  })
+})
+
+afterEach(() => {
+  harvestsMap.clear()
+  QueryBus.clearHandlers()
+})
+```
+
+**Key differences from repository tests:**
+- No `InMemory<Entity>Repository` for the cross-domain entity — use `InMemoryQueryBus` instead
+- Constructor args decrease (cross-domain repos removed)
+- Response data is a plain object, not a domain entity
+- Error imports change to local (`./errors/`) instead of cross-domain paths
+
+See `query-bus.md` for the full testing patterns and handler test examples.
+
 ---
 
 ## 2. Factory

--- a/coding-patterns/backend/use-case.md
+++ b/coding-patterns/backend/use-case.md
@@ -379,7 +379,9 @@ import { right, type Either } from '@/core/either'
 import type { CursorPaginationMeta } from '@/core/repositories/pagination-params'
 import type { AuditLog } from '@/domain/audit-log/enterprise/entities/audit-log'
 import type { AuditLogRepository } from '@/domain/audit-log/application/repositories/audit-log-repository'
-import type { UsersRepository } from '@/domain/user/application/repositories/users-repository'
+import { QueryBus } from '@/core/query-bus/query-bus'
+import { FindUsersByIdsQuery, type FindUsersByIdsQueryResult }
+  from '@/domain/user/application/queries/find-users-by-ids.query'
 import type { <Related>Repository } from '@/domain/<domain>/application/repositories/<related>-repository'
 import { extractChangeIds } from '@/shared/utils/extract-change-ids'
 
@@ -404,8 +406,7 @@ type List<Entity>AuditLogsUseCaseResponse = Either<
 export class List<Entity>AuditLogsUseCase {
   constructor(
     private auditLogRepository: AuditLogRepository,
-    private usersRepository: UsersRepository,
-    private <related>Repository: <Related>Repository,  // only if entity has foreign IDs to resolve
+    private <related>Repository: <Related>Repository,  // only if entity has foreign IDs to resolve (same domain)
   ) {}
 
   async execute({
@@ -420,12 +421,14 @@ export class List<Entity>AuditLogsUseCase {
       limit,
     })
 
-    // 1. Resolve actor names
+    // 1. Resolve actor names via QueryBus (User is a different domain)
     const actorIds = [...new Set(result.items.map((log) => log.actorId))]
-    const actors = await this.usersRepository.findManyByIds(actorIds)
-    const actorNames = new Map(actors.map((a) => [a.id.toString(), a.name]))
+    const actors = await QueryBus.execute<FindUsersByIdsQueryResult>(
+      new FindUsersByIdsQuery(actorIds),
+    )
+    const actorNames = new Map(actors.map((a) => [a.id, a.name]))
 
-    // 2. Resolve domain-specific foreign IDs from changes
+    // 2. Resolve domain-specific foreign IDs from changes (same-domain repos only)
     const resolvedNames = new Map<string, string>()
 
     const relatedIds = extractChangeIds(result.items, '<relatedField>Id')
@@ -447,6 +450,8 @@ export class List<Entity>AuditLogsUseCase {
 ```
 
 **Key patterns:**
+- Actor name resolution uses **QueryBus** (`FindUsersByIdsQuery`) — User is a different domain, never import `UsersRepository` directly
+- Domain-specific foreign ID resolution (e.g. variety → cropType) uses **direct repository injection** — these are within the same domain
 - Each domain use case knows which foreign IDs exist in its changes (e.g. variety knows `cropTypeId`, harvest knows `cropTypeId` + `varietyId`)
 - Use `extractChangeIds()` from `@/shared/utils/extract-change-ids` to extract IDs from `{ from, to }` change fields
 - Batch-load with `findManyByIds()` — never loop with individual `findById` calls
@@ -503,6 +508,37 @@ await this.<entity>Repository.save(entity)
 
 ---
 
+## Cross-domain data access
+
+Use cases **never** import repositories or error classes from other domains. When a use case needs data from another domain, use the QueryBus:
+
+```ts
+import { QueryBus } from '@/core/query-bus/query-bus'
+import { FindHarvestQuery, type FindHarvestQueryResult }
+  from '@/domain/crop/harvests/application/queries/find-harvest.query'
+import { HarvestNotFoundError } from './errors/harvest-not-found-error'  // local copy
+
+const harvest = await QueryBus.execute<FindHarvestQueryResult>(
+  new FindHarvestQuery(harvestId),
+)
+
+if (!harvest) {
+  return left(new HarvestNotFoundError(harvestId))
+}
+```
+
+**What's allowed to import from other domains:**
+- Query contracts (`application/queries/*.query.ts`) — pure data types, no dependencies
+- Nothing else — no repositories, no error classes, no entities
+
+**What's NOT cross-domain:**
+- Subdomains within the same domain (e.g., crop/harvests → crop/crop-types) — direct repository import is fine
+- `AuditLogRepository` — shared service, import freely
+
+See `query-bus.md` for the full pattern, existing queries, and how to add new ones.
+
+---
+
 ## Rules
 
 - Always `@Injectable()` — use cases are NestJS providers (this is a pragmatic trade-off: pure DDD avoids framework decorators in domain, but NestJS requires `@Injectable()` for dependency injection without custom provider factories)
@@ -511,6 +547,7 @@ await this.<entity>Repository.save(entity)
 - Left side lists all possible error types — if none, use `null`
 - Always include a one-line JSDoc comment describing what the use case does
 - **Never import** Prisma, HTTP types (Request, Response), or NestJS decorators beyond `@Injectable()`
+- **Never import** repositories or error classes from other domains — use QueryBus for cross-domain data (see `query-bus.md`)
 - **Never contain business logic** — business rules belong in the entity
 - **Never call another use case** — compose at the controller level if needed
 - List use cases always return `PaginationMeta` — never return unbounded arrays

--- a/shared-phases.md
+++ b/shared-phases.md
@@ -72,6 +72,7 @@ cd frontend && pnpm audit
 - Paginated results on all list use cases (offset or cursor)
 - No N+1 queries in repository implementations (no queries inside loops)
 - No logging in domain layer (`src/domain/`)
+- **No cross-domain repository or error imports in use cases** — use cases must use QueryBus for cross-domain data (see `coding-patterns/backend/query-bus.md`). Allowed cross-domain imports in use cases: query contracts (`application/queries/*.query.ts`) and `AuditLogRepository` (shared service). Subscribers are exempt.
 The checks above are mandatory for Phase 3. For a deeper audit, run `/compliance-check` (optional — recommended for new domains or large features).
 
 **On threshold failure:**


### PR DESCRIPTION
## Summary
Document the new QueryBus pattern and update all affected coding patterns, architecture docs, and validation phases.

## Changes
- **New**: `coding-patterns/backend/query-bus.md` — full pattern (when to use, file locations, core primitives, query contracts, handlers, module wiring, usage in use cases, local errors, existing queries table, testing patterns, adding new queries, module boundary rules, anti-patterns)
- **Updated**: `architecture.md` — QueryBus in cross-cutting concerns table, module relationship notes, decision log entry (2026-03-17)
- **Updated**: `coding-patterns/backend/use-case.md` — cross-domain data access section, audit log pattern using QueryBus
- **Updated**: `coding-patterns/backend/events.md` — DomainEvents vs QueryBus callout
- **Updated**: `coding-patterns/backend/tests.md` — InMemoryQueryBus testing patterns for use case tests
- **Updated**: `shared-phases.md` — module boundary check in Phase 3 architectural conformance
- **Updated**: `CLAUDE.md` — project structure (core/query-bus, queries, handlers), non-negotiable rule #8

## Related
Closes fellipefreiire/farm-app-docs#20

## Checklist
- [x] Docs updated
- [x] Cross-references between docs verified